### PR TITLE
use vtk qt at run-time

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,7 @@ requirements:
     - numpy
     - proj >=8.2
     - python
-    - vtk >=9.1 qt*  # [linux]
-    - vtk >=9.1         # [not linux]
+    - vtk >=9.1
     - wxpython
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: a28e4c613371d6add6b45a790d0702db842e11cefc31e2260d7941d4eae3231e
 
 build:
-  number: 2
+  number: 3
   osx_is_app: true  # [osx]
 
 requirements:
@@ -32,7 +32,7 @@ requirements:
     - numpy
     - proj >=8.2
     - python
-    - vtk >=9.1 osmesa*  # [linux]
+    - vtk >=9.1 qt*  # [linux]
     - vtk >=9.1         # [not linux]
     - wxpython
 


### PR DESCRIPTION
this is horrible, but it may work for now.

we need vtk osmesa to have working build deps, but vtk qt at run-time, seemingly because of a bug in vtk not yet fixed in conda-forge:

https://gitlab.kitware.com/paraview/paraview/-/issues/20717

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
